### PR TITLE
Add tests for logout functionality

### DIFF
--- a/backend/tests/Feature/LogoutTest.php
+++ b/backend/tests/Feature/LogoutTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_logout()
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        $this->withHeaders(['Authorization' => "Bearer $token"])
+            ->postJson('/api/logout')
+            ->assertStatus(200)
+            ->assertJson(['message' => 'Logout successful.']);
+
+        $this->assertDatabaseMissing('personal_access_tokens', ['tokenable_id' => $user->id]);
+    }
+
+    public function test_unauthenticated_user_cannot_logout()
+    {
+        $this->postJson('/api/logout')
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
- Implemented `LogoutTest` to ensure logout endpoint functionality.
- Validated token revocation upon logout for authenticated users.
- Confirmed unauthorized access to the logout endpoint returns a 401 status.

**Files Modified:**
- `backend/tests/Feature/LogoutTest.php`: Added test cases for logout behavior, including token revocation and access restrictions.