### PR TITLE
Implement token refresh functionality

### DIFF
--- a/backend/app/Http/Controllers/Auth/TokenRefreshController.php
+++ b/backend/app/Http/Controllers/Auth/TokenRefreshController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class TokenRefreshController extends Controller
+{
+    /**
+     * Refresh the user's authentication token.
+     */
+    public function refresh(Request $request)
+    {
+        $user = $request->user();
+
+        // Revoke the current token to prevent misuse
+        $currentToken = $user->currentAccessToken();
+        if ($currentToken) {
+            $currentToken->delete();
+        }
+
+        // Create a new token
+        $newToken = $user->createToken('auth_token')->plainTextToken;
+
+        return response()->json([
+            'message' => 'Token refreshed successfully.',
+            'data'    => [
+                'token' => $newToken,
+            ],
+        ], 200);
+    }
+}

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -9,9 +9,9 @@ return [
         Sanctum::currentApplicationUrlWithPort()
     ))),
     'guard' => ['web'],
-    'expiration' => null,
+    'expiration' => 60,
     'middleware' => [
         'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
-        'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
+        'encrypt_cookies'   => App\Http\Middleware\EncryptCookies::class,
     ],
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Auth\EmailVerificationController;
 use App\Http\Controllers\Auth\PasswordResetController;
+use App\Http\Controllers\Auth\TokenRefreshController;
 
 Route::post('/register', [RegisteredUserController::class, 'store']);
 Route::post('/login', [AuthenticatedSessionController::class, 'store']);
@@ -20,3 +21,6 @@ Route::get('/verify-email/{id}/{hash}', [EmailVerificationController::class, 've
 // Password Reset Routes
 Route::post('/forgot-password', [PasswordResetController::class, 'sendResetLinkEmail'])->middleware('guest');
 Route::post('/reset-password', [PasswordResetController::class, 'reset'])->middleware('guest');
+
+// Token Refresh Route
+Route::post('/refresh-token', [TokenRefreshController::class, 'refresh'])->middleware('auth:sanctum');

--- a/backend/tests/Feature/TokenRefreshTest.php
+++ b/backend/tests/Feature/TokenRefreshTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class TokenRefreshTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_refresh_token()
+    {
+        $user = User::factory()->create();
+
+        // Create a token
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        // Use the token to refresh
+        $response = $this->withHeaders(['Authorization' => "Bearer $token"])
+            ->postJson('/api/refresh-token');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'message',
+                'data' => [
+                    'token',
+                ],
+            ]);
+
+        // Assert that the old token is revoked
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+            'token'        => hash('sha256', explode('|', $token, 2)[1]),
+        ]);
+
+        // Assert that a new token is issued
+        $this->assertNotNull($response->json('data.token'));
+    }
+
+    public function test_cannot_refresh_with_invalid_token()
+    {
+        $response = $this->withHeaders(['Authorization' => "Bearer invalid_token"])
+            ->postJson('/api/refresh-token');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_cannot_refresh_with_expired_token()
+    {
+        $user = User::factory()->create();
+
+        // Set token expiration to 1 minute
+        config(['sanctum.expiration' => 1]);
+
+        // Create a token
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        // Travel 2 minutes into the future
+        Carbon::setTestNow(Carbon::now()->addMinutes(2));
+
+        $response = $this->withHeaders(['Authorization' => "Bearer $token"])
+            ->postJson('/api/refresh-token');
+
+        $response->assertStatus(401);
+
+        // Reset time
+        Carbon::setTestNow();
+    }
+
+    public function test_can_refresh_before_token_expires()
+    {
+        $user = User::factory()->create();
+
+        // Set token expiration to 60 minutes
+        config(['sanctum.expiration' => 60]);
+
+        // Create a token
+        $token = $user->createToken('auth_token')->plainTextToken;
+
+        // Travel 59 minutes into the future
+        Carbon::setTestNow(Carbon::now()->addMinutes(59));
+
+        $response = $this->withHeaders(['Authorization' => "Bearer $token"])
+            ->postJson('/api/refresh-token');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'message',
+                'data' => [
+                    'token',
+                ],
+            ]);
+
+        // Reset time
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
This pull request implements the token refresh feature for API sessions, enhancing security by allowing users to refresh their tokens before expiration. The changes include:

- **Sanctum Configuration**: Set token expiration policy to 60 minutes.
- **TokenRefreshController**: Created controller to handle token refresh functionality.
- **API Route**: Added `/refresh-token` route for token refresh, requiring authentication.
- **Tests**: Added tests in `TokenRefreshTest.php` to confirm:
  - Tokens are refreshed correctly.
  - Expired tokens are invalidated and new tokens issued.
  - Proper error handling for invalid and expired tokens.

**Files Modified:**
- `backend\config\sanctum.php`: Configured token expiration.
- `backend\app\Http\Controllers\Auth\TokenRefreshController.php`: Added token refresh logic.
- `backend\routes\api.php`: Registered `/refresh-token` route.
- `backend\tests\Feature\TokenRefreshTest.php`: Implemented token refresh tests.

This feature improves the security and user experience for authenticated API requests by ensuring session continuity through token refresh capabilities.