### PR TITLE
Implement login throttling and lockout

### DIFF
--- a/backend/tests/Feature/LoginTest.php
+++ b/backend/tests/Feature/LoginTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Tests\TestCase;
 
 class LoginTest extends TestCase
@@ -13,12 +14,12 @@ class LoginTest extends TestCase
     public function test_user_can_login_with_correct_credentials()
     {
         $user = User::factory()->create([
-            'password' => bcrypt('SecurePass123!'),
+            'password'          => bcrypt('SecurePass123!'),
             'email_verified_at' => now(),
         ]);
 
         $response = $this->postJson('/api/login', [
-            'email' => $user->email,
+            'email'    => $user->email,
             'password' => 'SecurePass123!',
         ]);
 
@@ -35,12 +36,12 @@ class LoginTest extends TestCase
     public function test_login_fails_with_incorrect_password()
     {
         $user = User::factory()->create([
-            'password' => bcrypt('SecurePass123!'),
+            'password'          => bcrypt('SecurePass123!'),
             'email_verified_at' => now(),
         ]);
 
         $response = $this->postJson('/api/login', [
-            'email' => $user->email,
+            'email'    => $user->email,
             'password' => 'WrongPassword!',
         ]);
 
@@ -53,12 +54,12 @@ class LoginTest extends TestCase
     public function test_login_fails_if_email_not_verified()
     {
         $user = User::factory()->create([
-            'password' => bcrypt('SecurePass123!'),
+            'password'          => bcrypt('SecurePass123!'),
             'email_verified_at' => null,
         ]);
 
         $response = $this->postJson('/api/login', [
-            'email' => $user->email,
+            'email'    => $user->email,
             'password' => 'SecurePass123!',
         ]);
 
@@ -74,5 +75,96 @@ class LoginTest extends TestCase
 
         $response->assertStatus(422)
                  ->assertJsonValidationErrors(['email', 'password']);
+    }
+
+    public function test_user_is_locked_out_after_too_many_failed_attempts()
+    {
+        $user = User::factory()->create([
+            'password'          => bcrypt('SecurePass123!'),
+            'email_verified_at' => now(),
+        ]);
+
+        $credentials = [
+            'email'    => $user->email,
+            'password' => 'WrongPassword!',
+        ];
+
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->postJson('/api/login', $credentials);
+            $response->assertStatus(401);
+        }
+
+        $response = $this->postJson('/api/login', $credentials);
+        $response->assertStatus(429)
+                 ->assertJsonStructure(['message', 'retry_after']);
+
+        $this->assertTrue(isset($response->json()['retry_after']));
+    }
+
+    public function test_user_can_login_after_lockout_period()
+    {
+        $user = User::factory()->create([
+            'password'          => bcrypt('SecurePass123!'),
+            'email_verified_at' => now(),
+        ]);
+
+        $credentials = [
+            'email'    => $user->email,
+            'password' => 'WrongPassword!',
+        ];
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson('/api/login', $credentials);
+        }
+
+        Carbon::setTestNow(Carbon::now()->addSeconds(61));
+
+        $response = $this->postJson('/api/login', [
+            'email'    => $user->email,
+            'password' => 'SecurePass123!',
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'message',
+                     'data' => [
+                         'user',
+                         'token',
+                     ],
+                 ]);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_successful_login_clears_failed_attempts()
+    {
+        $user = User::factory()->create([
+            'password'          => bcrypt('SecurePass123!'),
+            'email_verified_at' => now(),
+        ]);
+
+        $credentials = [
+            'email'    => $user->email,
+            'password' => 'WrongPassword!',
+        ];
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->postJson('/api/login', $credentials)->assertStatus(401);
+        }
+
+        $this->postJson('/api/login', [
+            'email'    => $user->email,
+            'password' => 'SecurePass123!',
+        ])->assertStatus(200);
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->postJson('/api/login', $credentials)->assertStatus(401);
+        }
+
+        $response = $this->postJson('/api/login', $credentials);
+        $response->assertStatus(429)
+                 ->assertJsonStructure(['message', 'retry_after']);
+
+        $this->assertTrue(isset($response->json()['retry_after']));
     }
 }


### PR DESCRIPTION
This pull request introduces account lockout and throttling mechanisms for login attempts to enhance security and prevent brute-force attacks.

### Key Modifications
- **Rate Limiting and Lockout Configuration**
  - Configured rate limiting in `AuthenticatedSessionController` to limit login attempts to five.
  - Custom response messages display retry times and status for locked accounts.

- **Testing Throttling and Lockout**
  - Added test cases in `LoginTest` to ensure:
    - Lockout activates after five failed login attempts.
    - Lockout resets after a successful login or timeout.
    - Lockout period clears correctly after sufficient wait time.

### Files Modified:
- `backend/app/Http/Controllers/Auth/AuthenticatedSessionController.php`: Added throttling and lockout logic.
- `backend/tests/Feature/LoginTest.php`: Added tests to validate throttling and lockout.