### PR TITLE
Add endpoint for authenticated users to change passwords

### DIFF
--- a/api-server/app/Http/Controllers/Auth/ChangePasswordController.php
+++ b/api-server/app/Http/Controllers/Auth/ChangePasswordController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+
+class ChangePasswordController extends Controller
+{
+    /**
+     * Update the authenticated user's password.
+     *
+     * @group Authentication
+     * @authenticated
+     *
+     * @bodyParam current_password string required The user's current password.
+     * @bodyParam password string required The new password.
+     * @bodyParam password_confirmation string required Confirmation of the new password.
+     *
+     * @response 200 {
+     *   "message": "Password updated successfully."
+     * }
+     *
+     * @response 400 {
+     *   "message": "Current password does not match."
+     * }
+     *
+     * @response 422 {
+     *   "message": "Validation failed.",
+     *   "errors": {
+     *     "password": [
+     *       "The password must be at least 8 characters."
+     *     ]
+     *   }
+     * }
+     */
+    public function update(Request $request)
+    {
+        $user = $request->user();
+
+        $validator = Validator::make($request->all(), [
+            'current_password' => ['required', 'string'],
+            'password' => ['required', 'string', 'confirmed', Password::defaults()],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        if (!Hash::check($request->input('current_password'), $user->password)) {
+            return response()->json([
+                'message' => 'Current password does not match.',
+            ], 400);
+        }
+
+        $user->forceFill([
+            'password' => Hash::make($request->input('password')),
+        ])->save();
+
+        return response()->json([
+            'message' => 'Password updated successfully.',
+        ], 200);
+    }
+}

--- a/api-server/routes/api.php
+++ b/api-server/routes/api.php
@@ -7,54 +7,32 @@ use App\Http\Controllers\Auth\EmailVerificationController;
 use App\Http\Controllers\Auth\PasswordResetController;
 use App\Http\Controllers\Auth\TokenRefreshController;
 use App\Http\Controllers\Auth\TwoFactorAuthenticationController;
+use App\Http\Controllers\Auth\ChangePasswordController;
 
-Route::post("/register", [RegisteredUserController::class, "store"]);
-Route::post("/login", [AuthenticatedSessionController::class, "store"]);
-Route::post("/logout", [
-    AuthenticatedSessionController::class,
-    "destroy",
-])->middleware("auth:sanctum");
+Route::post('/register', [RegisteredUserController::class, 'store']);
+Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->middleware('auth:sanctum');
 
 // Email Verification Routes
-Route::post("/email/verification-notification", [
-    EmailVerificationController::class,
-    "sendVerificationEmail",
-])->middleware(["auth:sanctum", "throttle:6,1"]);
-Route::get("/verify-email/{id}/{hash}", [
-    EmailVerificationController::class,
-    "verify",
-])
-    ->name("verification.verify")
-    ->middleware(["signed", "throttle:6,1"]);
+Route::post('/email/verification-notification', [EmailVerificationController::class, 'sendVerificationEmail'])
+    ->middleware(['auth:sanctum', 'throttle:6,1']);
+Route::get('/verify-email/{id}/{hash}', [EmailVerificationController::class, 'verify'])
+    ->name('verification.verify')
+    ->middleware(['signed', 'throttle:6,1']);
 
 // Password Reset Routes
-Route::post("/forgot-password", [
-    PasswordResetController::class,
-    "sendResetLinkEmail",
-])->middleware("guest");
-Route::post("/reset-password", [
-    PasswordResetController::class,
-    "reset",
-])->middleware("guest");
+Route::post('/forgot-password', [PasswordResetController::class, 'sendResetLinkEmail'])->middleware('guest');
+Route::post('/reset-password', [PasswordResetController::class, 'reset'])->middleware('guest');
 
 // Token Refresh Route
-Route::post("/refresh-token", [
-    TokenRefreshController::class,
-    "refresh",
-])->middleware("auth:sanctum");
+Route::post('/refresh-token', [TokenRefreshController::class, 'refresh'])->middleware('auth:sanctum');
 
 // Two-Factor Authentication Routes
-Route::middleware(["auth:sanctum"])->group(function () {
-    Route::post("/two-factor-authentication/enable", [
-        TwoFactorAuthenticationController::class,
-        "enable",
-    ]);
-    Route::post("/two-factor-authentication/confirm", [
-        TwoFactorAuthenticationController::class,
-        "confirm",
-    ]);
-    Route::post("/two-factor-authentication/disable", [
-        TwoFactorAuthenticationController::class,
-        "disable",
-    ]);
+Route::middleware(['auth:sanctum'])->group(function () {
+    Route::post('/two-factor-authentication/enable', [TwoFactorAuthenticationController::class, 'enable']);
+    Route::post('/two-factor-authentication/confirm', [TwoFactorAuthenticationController::class, 'confirm']);
+    Route::post('/two-factor-authentication/disable', [TwoFactorAuthenticationController::class, 'disable']);
+
+    // Password Update Route
+    Route::post('/password/update', [ChangePasswordController::class, 'update']);
 });

--- a/api-server/tests/Feature/ChangePasswordTest.php
+++ b/api-server/tests/Feature/ChangePasswordTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ChangePasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_change_password()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('OldPassword123!'),
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/password/update', [
+            'current_password' => 'OldPassword123!',
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ]);
+
+        $response->assertStatus(200)->assertJson([
+            'message' => 'Password updated successfully.',
+        ]);
+
+        $this->assertTrue(Hash::check('NewPassword123!', $user->fresh()->password));
+    }
+
+    public function test_user_cannot_change_password_with_incorrect_current_password()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('OldPassword123!'),
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/password/update', [
+            'current_password' => 'WrongPassword!',
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ]);
+
+        $response->assertStatus(400)->assertJson([
+            'message' => 'Current password does not match.',
+        ]);
+    }
+
+    public function test_user_cannot_change_password_with_invalid_new_password()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('OldPassword123!'),
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/password/update', [
+            'current_password' => 'OldPassword123!',
+            'password' => 'short',
+            'password_confirmation' => 'short',
+        ]);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['password']);
+    }
+
+    public function test_guest_cannot_change_password()
+    {
+        $response = $this->postJson('/api/password/update', [
+            'current_password' => 'DoesNotMatter',
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ]);
+
+        $response->assertStatus(401);
+    }
+}

--- a/docs/api-server/docs/collection.json
+++ b/docs/api-server/docs/collection.json
@@ -10,7 +10,7 @@
     ],
     "info": {
         "name": "Fitness AI",
-        "_postman_id": "26ef753f-5319-4f27-b710-20e4da8f4fd8",
+        "_postman_id": "67540c5b-bd59-4e6b-9db0-857ab5a00cd9",
         "description": "",
         "schema": "https:\/\/schema.getpostman.com\/json\/collection\/v2.1.0\/collection.json"
     },
@@ -147,6 +147,53 @@
                             "header": [],
                             "code": 401,
                             "body": "{\n  \"message\": \"Unauthenticated.\"\n}",
+                            "name": ""
+                        }
+                    ]
+                },
+                {
+                    "name": "Update the authenticated user's password.",
+                    "request": {
+                        "url": {
+                            "host": "{{baseUrl}}",
+                            "path": "api\/password\/update",
+                            "query": [],
+                            "raw": "{{baseUrl}}\/api\/password\/update"
+                        },
+                        "method": "POST",
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application\/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application\/json"
+                            }
+                        ],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\"current_password\":\"voluptatum\",\"password\":\")B#Qz?{T8\\\"<Tx\",\"password_confirmation\":\"voluptatum\"}"
+                        },
+                        "description": ""
+                    },
+                    "response": [
+                        {
+                            "header": [],
+                            "code": 200,
+                            "body": "{\n  \"message\": \"Password updated successfully.\"\n}",
+                            "name": ""
+                        },
+                        {
+                            "header": [],
+                            "code": 400,
+                            "body": "{\n  \"message\": \"Current password does not match.\"\n}",
+                            "name": ""
+                        },
+                        {
+                            "header": [],
+                            "code": 422,
+                            "body": "{\n  \"message\": \"Validation failed.\",\n  \"errors\": {\n    \"password\": [\n      \"The password must be at least 8 characters.\"\n    ]\n  }\n}",
                             "name": ""
                         }
                     ]

--- a/docs/api-server/docs/index.html
+++ b/docs/api-server/docs/index.html
@@ -84,6 +84,9 @@
                                                                                 <li class="tocify-item level-2" data-unique="authentication-POSTapi-refresh-token">
                                 <a href="#authentication-POSTapi-refresh-token">Refresh the user's authentication token.</a>
                             </li>
+                                                                                <li class="tocify-item level-2" data-unique="authentication-POSTapi-password-update">
+                                <a href="#authentication-POSTapi-password-update">Update the authenticated user's password.</a>
+                            </li>
                                                                         </ul>
                             </ul>
                     <ul id="tocify-header-email-verification" class="tocify-header">
@@ -757,6 +760,249 @@ You can check the Dev Tools console for debugging information.</code></pre>
 <p>Example: <code>application/json</code></p>
             </div>
                         </form>
+
+                    <h2 id="authentication-POSTapi-password-update">Update the authenticated user&#039;s password.</h2>
+
+<p>
+<small class="badge badge-darkred">requires authentication</small>
+</p>
+
+
+
+<span id="example-requests-POSTapi-password-update">
+<blockquote>Example request:</blockquote>
+
+
+<div class="bash-example">
+    <pre><code class="language-bash">curl --request POST \
+    "http://127.0.0.1:8000/api/password/update" \
+    --header "Authorization: Bearer {YOUR_AUTH_KEY}" \
+    --header "Content-Type: application/json" \
+    --header "Accept: application/json" \
+    --data "{
+    \"current_password\": \"voluptatum\",
+    \"password\": \")B#Qz?{T8\\\"&lt;Tx\",
+    \"password_confirmation\": \"voluptatum\"
+}"
+</code></pre></div>
+
+
+<div class="javascript-example">
+    <pre><code class="language-javascript">const url = new URL(
+    "http://127.0.0.1:8000/api/password/update"
+);
+
+const headers = {
+    "Authorization": "Bearer {YOUR_AUTH_KEY}",
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "current_password": "voluptatum",
+    "password": ")B#Qz?{T8\"&lt;Tx",
+    "password_confirmation": "voluptatum"
+};
+
+fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+}).then(response =&gt; response.json());</code></pre></div>
+
+
+<div class="php-example">
+    <pre><code class="language-php">$client = new \GuzzleHttp\Client();
+$url = 'http://127.0.0.1:8000/api/password/update';
+$response = $client-&gt;post(
+    $url,
+    [
+        'headers' =&gt; [
+            'Authorization' =&gt; 'Bearer {YOUR_AUTH_KEY}',
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+        'json' =&gt; [
+            'current_password' =&gt; 'voluptatum',
+            'password' =&gt; ')B#Qz?{T8"&lt;Tx',
+            'password_confirmation' =&gt; 'voluptatum',
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre></div>
+
+
+<div class="python-example">
+    <pre><code class="language-python">import requests
+import json
+
+url = 'http://127.0.0.1:8000/api/password/update'
+payload = {
+    "current_password": "voluptatum",
+    "password": ")B#Qz?{T8\"&lt;Tx",
+    "password_confirmation": "voluptatum"
+}
+headers = {
+  'Authorization': 'Bearer {YOUR_AUTH_KEY}',
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+response = requests.request('POST', url, headers=headers, json=payload)
+response.json()</code></pre></div>
+
+</span>
+
+<span id="example-responses-POSTapi-password-update">
+            <blockquote>
+            <p>Example response (200):</p>
+        </blockquote>
+                <pre>
+
+<code class="language-json" style="max-height: 300px;">{
+    &quot;message&quot;: &quot;Password updated successfully.&quot;
+}</code>
+ </pre>
+            <blockquote>
+            <p>Example response (400):</p>
+        </blockquote>
+                <pre>
+
+<code class="language-json" style="max-height: 300px;">{
+    &quot;message&quot;: &quot;Current password does not match.&quot;
+}</code>
+ </pre>
+            <blockquote>
+            <p>Example response (422):</p>
+        </blockquote>
+                <pre>
+
+<code class="language-json" style="max-height: 300px;">{
+    &quot;message&quot;: &quot;Validation failed.&quot;,
+    &quot;errors&quot;: {
+        &quot;password&quot;: [
+            &quot;The password must be at least 8 characters.&quot;
+        ]
+    }
+}</code>
+ </pre>
+    </span>
+<span id="execution-results-POSTapi-password-update" hidden>
+    <blockquote>Received response<span
+                id="execution-response-status-POSTapi-password-update"></span>:
+    </blockquote>
+    <pre class="json"><code id="execution-response-content-POSTapi-password-update"
+      data-empty-response-text="<Empty response>" style="max-height: 400px;"></code></pre>
+</span>
+<span id="execution-error-POSTapi-password-update" hidden>
+    <blockquote>Request failed with error:</blockquote>
+    <pre><code id="execution-error-message-POSTapi-password-update">
+
+Tip: Check that you&#039;re properly connected to the network.
+If you&#039;re a maintainer of ths API, verify that your API is running and you&#039;ve enabled CORS.
+You can check the Dev Tools console for debugging information.</code></pre>
+</span>
+<form id="form-POSTapi-password-update" data-method="POST"
+      data-path="api/password/update"
+      data-authed="1"
+      data-hasfiles="0"
+      data-isarraybody="0"
+      autocomplete="off"
+      onsubmit="event.preventDefault(); executeTryOut('POSTapi-password-update', this);">
+    <h3>
+        Request&nbsp;&nbsp;&nbsp;
+                    <button type="button"
+                    style="background-color: #8fbcd4; padding: 5px 10px; border-radius: 5px; border-width: thin;"
+                    id="btn-tryout-POSTapi-password-update"
+                    onclick="tryItOut('POSTapi-password-update');">Try it out ⚡
+            </button>
+            <button type="button"
+                    style="background-color: #c97a7e; padding: 5px 10px; border-radius: 5px; border-width: thin;"
+                    id="btn-canceltryout-POSTapi-password-update"
+                    onclick="cancelTryOut('POSTapi-password-update');" hidden>Cancel 🛑
+            </button>&nbsp;&nbsp;
+            <button type="submit"
+                    style="background-color: #6ac174; padding: 5px 10px; border-radius: 5px; border-width: thin;"
+                    id="btn-executetryout-POSTapi-password-update"
+                    data-initial-text="Send Request 💥"
+                    data-loading-text="⏱ Sending..."
+                    hidden>Send Request 💥
+            </button>
+            </h3>
+            <p>
+            <small class="badge badge-black">POST</small>
+            <b><code>api/password/update</code></b>
+        </p>
+                <h4 class="fancy-heading-panel"><b>Headers</b></h4>
+                                <div style="padding-left: 28px; clear: unset;">
+                <b style="line-height: 2;"><code>Authorization</code></b>&nbsp;&nbsp;
+&nbsp;
+ &nbsp;
+                <input type="text" style="display: none"
+                              name="Authorization" class="auth-value"               data-endpoint="POSTapi-password-update"
+               value="Bearer {YOUR_AUTH_KEY}"
+               data-component="header">
+    <br>
+<p>Example: <code>Bearer {YOUR_AUTH_KEY}</code></p>
+            </div>
+                                <div style="padding-left: 28px; clear: unset;">
+                <b style="line-height: 2;"><code>Content-Type</code></b>&nbsp;&nbsp;
+&nbsp;
+ &nbsp;
+                <input type="text" style="display: none"
+                              name="Content-Type"                data-endpoint="POSTapi-password-update"
+               value="application/json"
+               data-component="header">
+    <br>
+<p>Example: <code>application/json</code></p>
+            </div>
+                                <div style="padding-left: 28px; clear: unset;">
+                <b style="line-height: 2;"><code>Accept</code></b>&nbsp;&nbsp;
+&nbsp;
+ &nbsp;
+                <input type="text" style="display: none"
+                              name="Accept"                data-endpoint="POSTapi-password-update"
+               value="application/json"
+               data-component="header">
+    <br>
+<p>Example: <code>application/json</code></p>
+            </div>
+                                <h4 class="fancy-heading-panel"><b>Body Parameters</b></h4>
+        <div style=" padding-left: 28px;  clear: unset;">
+            <b style="line-height: 2;"><code>current_password</code></b>&nbsp;&nbsp;
+<small>string</small>&nbsp;
+ &nbsp;
+                <input type="text" style="display: none"
+                              name="current_password"                data-endpoint="POSTapi-password-update"
+               value="voluptatum"
+               data-component="body">
+    <br>
+<p>The user's current password. Example: <code>voluptatum</code></p>
+        </div>
+                <div style=" padding-left: 28px;  clear: unset;">
+            <b style="line-height: 2;"><code>password</code></b>&nbsp;&nbsp;
+<small>string</small>&nbsp;
+ &nbsp;
+                <input type="text" style="display: none"
+                              name="password"                data-endpoint="POSTapi-password-update"
+               value=")B#Qz?{T8"<Tx"
+               data-component="body">
+    <br>
+<p>The new password. Example: <code>)B#Qz?{T8"&lt;Tx</code></p>
+        </div>
+                <div style=" padding-left: 28px;  clear: unset;">
+            <b style="line-height: 2;"><code>password_confirmation</code></b>&nbsp;&nbsp;
+<small>string</small>&nbsp;
+ &nbsp;
+                <input type="text" style="display: none"
+                              name="password_confirmation"                data-endpoint="POSTapi-password-update"
+               value="voluptatum"
+               data-component="body">
+    <br>
+<p>Confirmation of the new password. Example: <code>voluptatum</code></p>
+        </div>
+        </form>
 
                 <h1 id="email-verification">Email Verification</h1>
 

--- a/docs/api-server/docs/openapi.yaml
+++ b/docs/api-server/docs/openapi.yaml
@@ -196,6 +196,89 @@ paths:
                     example: Unauthenticated.
       tags:
         - Authentication
+  /api/password/update:
+    post:
+      summary: 'Update the authenticated user''s password.'
+      operationId: updateTheAuthenticatedUsersPassword
+      description: ''
+      parameters: []
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  message: 'Password updated successfully.'
+                properties:
+                  message:
+                    type: string
+                    example: 'Password updated successfully.'
+        400:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  message: 'Current password does not match.'
+                properties:
+                  message:
+                    type: string
+                    example: 'Current password does not match.'
+        422:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  message: 'Validation failed.'
+                  errors:
+                    password:
+                      - 'The password must be at least 8 characters.'
+                properties:
+                  message:
+                    type: string
+                    example: 'Validation failed.'
+                  errors:
+                    type: object
+                    properties:
+                      password:
+                        type: array
+                        example:
+                          - 'The password must be at least 8 characters.'
+                        items:
+                          type: string
+      tags:
+        - Authentication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                current_password:
+                  type: string
+                  description: 'The user''s current password.'
+                  example: voluptatum
+                  nullable: false
+                password:
+                  type: string
+                  description: 'The new password.'
+                  example: ')B#Qz?{T8"<Tx'
+                  nullable: false
+                password_confirmation:
+                  type: string
+                  description: 'Confirmation of the new password.'
+                  example: voluptatum
+                  nullable: false
+              required:
+                - current_password
+                - password
+                - password_confirmation
   /api/email/verification-notification:
     post:
       summary: 'Send a new email verification notification.'


### PR DESCRIPTION
This pull request introduces a feature that allows authenticated users to update their passwords securely. The changes include:

- **ChangePasswordController:** Implements the logic for validating the current password and updating the new password.
- **API Route:** Adds a POST `/password/update` route to the API, protected by the `auth:sanctum` middleware.
- **Tests:** Includes comprehensive test cases in `ChangePasswordTest` to verify functionality, including successful updates, validation errors, and unauthorized access scenarios.
- **Documentation:** Updates the API documentation using Scribe to reflect the new endpoint, ensuring clarity and usability for API consumers.

**Files Modified:**
- `api-server/app/Http/Controllers/Auth/ChangePasswordController.php`: Implements the password update functionality.
- `api-server/routes/api.php`: Adds the route for the password update feature.
- `api-server/tests/Feature/ChangePasswordTest.php`: Includes test cases for the new feature.
- Auto-generated API documentation: Updated to reflect the new endpoint.

This addition improves user security by enabling seamless password updates while adhering to best practices for validation and authentication.