### PR TITLE
Send Verification Email During Registration

### DIFF
--- a/api-server/app/Notifications/RegistrationTokenNotification.php
+++ b/api-server/app/Notifications/RegistrationTokenNotification.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class RegistrationTokenNotification extends Notification
+{
+    use Queueable;
+
+    protected $token;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     */
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail($notifiable)
+    {
+        $frontendUrl = config('app.frontend_url') . '/complete-registration?token=' . $this->token;
+
+        return (new \Illuminate\Notifications\Messages\MailMessage)
+            ->subject('Complete Your Registration')
+            ->line('Please click the button below to complete your registration.')
+            ->action('Complete Registration', $frontendUrl)
+            ->line('This link will expire in 1 hour.');
+    }
+}


### PR DESCRIPTION
This pull request implements functionality to send a verification email containing a registration token after a user initiates the registration process. The email includes a link that redirects to the frontend page for completing registration.

### Changes:
- Added `RegistrationTokenNotification` to handle email content and delivery.
- Modified `RegisteredUserController` to send a verification email upon registration initiation.
- Implemented error handling for email delivery failures to ensure a robust process.

### Files Modified:
1. **`app\Notifications\RegistrationTokenNotification.php`**
   - Added notification class to manage email content and provide a link for completing registration.

2. **`app\Http\Controllers\Auth\RegisteredUserController.php`**
   - Updated the `initiate` method to send a verification email using the `RegistrationTokenNotification`.