### PR TITLE
Add resend verification email functionality

### DIFF
--- a/api-server/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/api-server/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -7,6 +7,7 @@ use App\Models\RegistrationToken;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use App\Notifications\RegistrationTokenNotification;
 
@@ -88,6 +89,110 @@ class RegisteredUserController extends Controller
         return response()->json(
             [
                 'message' => 'Registration initiated successfully.',
+            ],
+            200
+        );
+    }
+
+    /**
+     * Resend the registration verification email.
+     *
+     * @group Registration
+     * @unauthenticated
+     *
+     * @bodyParam email string required The user's email address.
+     *
+     * @response 200 {
+     *   "message": "Verification email resent successfully."
+     * }
+     *
+     * @response 404 {
+     *   "message": "Registration token not found."
+     * }
+     *
+     * @response 429 {
+     *   "message": "Too many resend attempts. Please try again later."
+     * }
+     *
+     * @response 500 {
+     *   "message": "Failed to resend verification email."
+     * }
+     */
+    public function resend(Request $request)
+    {
+        $email = $request->input('email');
+
+        $validator = Validator::make($request->all(), [
+            'email' => [
+                'required',
+                'email',
+                'string',
+                'max:255',
+            ],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(
+                [
+                    'message' => 'Invalid email address.',
+                    'errors' => $validator->errors(),
+                ],
+                422
+            );
+        }
+
+        $throttleKey = 'resend_verification_email:' . Str::lower($email) . '|' . $request->ip();
+
+        if (RateLimiter::tooManyAttempts($throttleKey, 3)) {
+            $seconds = RateLimiter::availableIn($throttleKey);
+            return response()->json(
+                [
+                    'message' => 'Too many resend attempts. Please try again in ' . $seconds . ' seconds.',
+                    'retry_after' => $seconds,
+                ],
+                429
+            );
+        }
+
+        $registrationToken = RegistrationToken::where('email', $email)->first();
+
+        if (!$registrationToken) {
+            return response()->json(
+                [
+                    'message' => 'Registration token not found.',
+                ],
+                404
+            );
+        }
+
+        // Generate a new token
+        $token = Str::random(60);
+
+        // Update the token's expiration time
+        $registrationToken->update([
+            'token' => hash('sha256', $token),
+            'expires_at' => now()->addHour(),
+        ]);
+
+        try {
+            // Send the verification email
+            Notification::route('mail', $email)
+                ->notify(new RegistrationTokenNotification($token));
+        } catch (\Exception $e) {
+            // Handle email sending failure
+            return response()->json(
+                [
+                    'message' => 'Failed to resend verification email.',
+                ],
+                500
+            );
+        }
+
+        RateLimiter::hit($throttleKey, 60);
+
+        return response()->json(
+            [
+                'message' => 'Verification email resent successfully.',
             ],
             200
         );

--- a/api-server/routes/api.php
+++ b/api-server/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Auth\TwoFactorAuthenticationController;
 use App\Http\Controllers\Auth\ChangePasswordController;
 
 Route::post('/register/initiate', [RegisteredUserController::class, 'initiate']);
+Route::post('/register/resend', [RegisteredUserController::class, 'resend']);
 Route::post('/register', [RegisteredUserController::class, 'store']);
 Route::post('/login', [AuthenticatedSessionController::class, 'store']);
 Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->middleware('auth:sanctum');


### PR DESCRIPTION
This pull request introduces functionality for resending the registration verification email. It includes the following updates:

- Added an API endpoint `/register/resend` to allow users to resend the verification email.
- Implemented rate limiting to prevent abuse of the resend functionality (3 attempts per minute).
- Updated the token's expiration time upon resending to ensure valid registrations.
- Enhanced error handling for scenarios such as missing tokens or email delivery failures.

**Modified Files:**  
- `api-server/app/Http/Controllers/Auth/RegisteredUserController.php`:  
  - Added the `resend` method to handle verification email resending logic.
  - Integrated rate limiting and token expiration updates.

- `api-server/routes/api.php`:  
  - Added the `/register/resend` route linked to the `RegisteredUserController@resend` method.