### PR TITLE
Add cleanup task for expired registration tokens

### DIFF
--- a/api-server/app/Console/Commands/CleanUpExpiredRegistrationTokens.php
+++ b/api-server/app/Console/Commands/CleanUpExpiredRegistrationTokens.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\RegistrationToken;
+
+class CleanUpExpiredRegistrationTokens extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'registration-tokens:cleanup';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete expired registration tokens from the database';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $count = RegistrationToken::where('expires_at', '<', now())->delete();
+
+        $this->info("Deleted {$count} expired registration tokens.");
+    }
+}

--- a/api-server/app/Console/Kernel.php
+++ b/api-server/app/Console/Kernel.php
@@ -9,13 +9,14 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule)
     {
-        // Define scheduled tasks here
+        // Schedule the cleanup of expired registration tokens every hour
+        $schedule->command('registration-tokens:cleanup')->hourly();
     }
 
     protected function commands()
     {
-        $this->load(__DIR__ . "/Commands");
+        $this->load(__DIR__ . '/Commands');
 
-        require base_path("routes/console.php");
+        require base_path('routes/console.php');
     }
 }


### PR DESCRIPTION
This pull request implements a scheduled task to clean up expired registration tokens from the database, ensuring obsolete records are removed regularly.

### Changes:
- **Added**: `CleanUpExpiredRegistrationTokens` console command to delete expired tokens.
- **Updated**: `Console\Kernel.php` to schedule the cleanup command to run hourly.

### Purpose:
- Improve database hygiene by removing expired tokens.
- Prevent the usage of expired tokens for registration.
- Optimize system performance by cleaning up unnecessary data.

### Files Modified:
1. `api-server\app\Console\Commands\CleanUpExpiredRegistrationTokens.php`
   - Added a new command to delete expired registration tokens.
2. `api-server\app\Console\Kernel.php`
   - Scheduled the new command to execute hourly.