### PR TITLE
Add dynamic profile schema for flexible user attributes

### DIFF
--- a/api-server/database/migrations/2024_12_08_074924_create_user_profiles_table.php
+++ b/api-server/database/migrations/2024_12_08_074924_create_user_profiles_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('user_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('user_profiles');
+    }
+};

--- a/api-server/database/migrations/2024_12_08_075147_create_user_profile_attributes_table.php
+++ b/api-server/database/migrations/2024_12_08_075147_create_user_profile_attributes_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::create('user_profile_attributes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_profile_id')->constrained('user_profiles')->onDelete('cascade');
+            $table->string('attribute_key');
+            $table->text('attribute_value')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_profile_id', 'attribute_key']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('user_profile_attributes');
+    }
+};


### PR DESCRIPTION
This pull request introduces a flexible schema to support dynamic user profile attributes. The following changes have been implemented:

- **New migrations**:
  - Created `user_profiles` table to link profiles with existing users.
  - Created `user_profile_attributes` table for storing key-value pairs of dynamic attributes.

These additions lay the foundation for dynamic user profile handling, allowing for flexible extensions without schema changes.

**Files Modified/Added:**
- `database/migrations/2024_12_08_000000_create_user_profiles_table.php`:
  - Defines the `user_profiles` table, linking profiles to users.
- `database/migrations/2024_12_08_000001_create_user_profile_attributes_table.php`:
  - Defines the `user_profile_attributes` table, including a composite index for efficient querying.