### PR TITLE
Remove email_verified_at column from User model and related references

### DIFF
--- a/api-server/app/Actions/Fortify/CreateNewUser.php
+++ b/api-server/app/Actions/Fortify/CreateNewUser.php
@@ -30,7 +30,6 @@ class CreateNewUser implements CreatesNewUsers
             "name" => $input["name"],
             "email" => $input["email"],
             "password" => Hash::make($input["password"]),
-            "email_verified_at" => now(),
         ]);
     }
 }

--- a/api-server/app/Models/User.php
+++ b/api-server/app/Models/User.php
@@ -22,7 +22,6 @@ class User extends Authenticatable
     ];
 
     protected $casts = [
-        'email_verified_at' => 'datetime',
         'two_factor_confirmed_at' => 'datetime',
     ];
 

--- a/api-server/database/factories/UserFactory.php
+++ b/api-server/database/factories/UserFactory.php
@@ -10,10 +10,7 @@ class UserFactory extends Factory
     {
         return [
             "name" => fake()->name(),
-            "email" => fake()
-                ->unique()
-                ->safeEmail(),
-            "email_verified_at" => now(),
+            "email" => fake()->unique()->safeEmail(),
             "password" =>
                 '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         ];

--- a/api-server/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/api-server/database/migrations/2014_10_12_000000_create_users_table.php
@@ -11,7 +11,6 @@ return new class extends Migration {
             $table->id();
             $table->string("name");
             $table->string("email")->unique();
-            $table->timestamp("email_verified_at");
             $table->string("password");
             $table->timestamps();
         });

--- a/api-server/tests/Unit/Models/UserTest.php
+++ b/api-server/tests/Unit/Models/UserTest.php
@@ -75,10 +75,8 @@ class UserTest extends TestCase
     public function test_date_attributes_are_cast_correctly()
     {
         $user = User::factory()->create([
-            'email_verified_at' => now(),
             'two_factor_confirmed_at' => now(),
         ]);
-        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $user->email_verified_at);
         $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $user->two_factor_confirmed_at);
     }
 


### PR DESCRIPTION
This pull request removes the `email_verified_at` column from the `users` table and eliminates all related references in the project. The email verification process is deemed redundant as verification occurs during registration.  

**Changes:**  
- **`database/migrations/2014_10_12_000000_create_users_table.php`:** Removed the `email_verified_at` column from the migration file.
- **`app/Models/User.php`:** Removed the `email_verified_at` cast property from the model.
- **`app/Actions/Fortify/CreateNewUser.php`:** Removed the assignment of `email_verified_at` during user creation.
- **`database/factories/UserFactory.php`:** Removed the default generation of `email_verified_at`.
- **`tests/Unit/Models/UserTest.php`:** Updated tests by removing assertions for `email_verified_at`.

**Files Modified:**  
- `api-server\database\migrations\2014_10_12_000000_create_users_table.php`
- `api-server\app\Models\User.php`
- `api-server\app\Actions\Fortify\CreateNewUser.php`
- `api-server\database\factories\UserFactory.php`
- `api-server\tests\Unit\Models\UserTest.php`