### PR TITLE
Feature/setup/update defaults

### DIFF
--- a/frontend/src/pages/setup/StepContent.tsx
+++ b/frontend/src/pages/setup/StepContent.tsx
@@ -32,7 +32,7 @@ const StepContent: React.FC<StepContentProps> = ({ stepId, data, onChange }) => 
         case "measurement":
             return (
                 <MeasurementStep
-                    measurement={data.measurement}
+                    data={data}
                     onChange={onChange}
                 />
             );

--- a/frontend/src/pages/setup/steps/MeasurementStep.tsx
+++ b/frontend/src/pages/setup/steps/MeasurementStep.tsx
@@ -30,7 +30,7 @@ export const MeasurementStep: React.FC<MeasurementStepProps> = ({ data, onChange
             // Convert height from cm to inches
             const heightInInches = Math.round(data.height / 2.54);
             onChange("height", heightInInches);
-            onChange("heightUnit", heightInInches);
+            onChange("heightUnit", "in");
         }
         onChange("measurement", measurement);
     }

--- a/frontend/src/pages/setup/steps/MeasurementStep.tsx
+++ b/frontend/src/pages/setup/steps/MeasurementStep.tsx
@@ -1,21 +1,38 @@
 import React from "react";
 import { Label } from "@/components/ui/label";
+import { SetupData } from "../SetupContext";
 
 interface MeasurementStepProps {
-    measurement: "metric" | "imperial"; // Current selected value
-    onChange: (key: string, value: string) => void; // Function to handle selection changes
+    data: SetupData;
+    onChange: (key: string, value: any) => void; // Function to handle selection changes
 };
 
-export const MeasurementStep: React.FC<MeasurementStepProps> = ({ measurement, onChange }) => {
+export const MeasurementStep: React.FC<MeasurementStepProps> = ({ data, onChange }) => {
+    const measurement = data.measurement;
     const updateData = (measurement: string) => {
-        onChange("measurement", measurement);
-        if (measurement === "metric") {
+        if (measurement === data.measurement) return;
+        if (measurement === "metric" && data.measurement === "imperial") {
+            // Convert weight from lbs to kg
+            const weightInKg = Math.round(data.weight * 0.453592);
+            onChange("weight", weightInKg);
             onChange("weightUnit", "kg");
+
+            // Convert height from inches to cm
+            const heightInCm = Math.round(data.height * 2.54);
+            onChange("height", heightInCm);
             onChange("heightUnit", "cm");
-        } else {
+        } else if (measurement === "imperial" && data.measurement === "metric") {
+            // Convert weight from kg to lbs
+            const weightInLbs = Math.round(data.weight * 2.20462);
+            onChange("weight", weightInLbs);
             onChange("weightUnit", "lbs");
-            onChange("heightUnit", "in");
+
+            // Convert height from cm to inches
+            const heightInInches = Math.round(data.height / 2.54);
+            onChange("height", heightInInches);
+            onChange("heightUnit", heightInInches);
         }
+        onChange("measurement", measurement);
     }
 
     return (


### PR DESCRIPTION
### Pull Request Title
Fix: Dynamic Unit Conversion for Weight and Height in MeasurementStep

### Description
This PR adds dynamic unit conversion when switching between Metric and Imperial measurement systems in the MeasurementStep component. Existing weight and height values are now converted instead of being reset.

### Changes Made
1. Added conversion logic:
   - Imperial → Metric:
     - Weight: lbs → kg (rounded)
     - Height: inches → cm (rounded)
   - Metric → Imperial:
     - Weight: kg → lbs (rounded)
     - Height: cm → inches (rounded)
2. Added an early return to prevent redundant updates when the selected measurement matches the current one.

### How to Test
1. Go to the MeasurementStep component.
2. Set custom weight and height values.
3. Switch between Metric and Imperial:
   - Verify that the weight and height are converted correctly.
   - Ensure no values are reset during the switch.

### Example Behavior
- Imperial → Metric:
   - 150 lbs → 68 kg
   - 70 inches → 178 cm
- Metric → Imperial:
   - 70 kg → 154 lbs
   - 170 cm → 67 inches

### Impact
- Improves user experience by preserving existing input data and dynamically converting values.
